### PR TITLE
feat(docker): sync global Claude Code commands and agents to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,9 @@ COPY --from=gh-ext-pr-check --chown=dev:dev . /home/dev/.local/share/gh/extensio
 COPY --from=gh-ext-ai-review --chown=dev:dev . /home/dev/.local/share/gh/extensions/gh-ai-review
 RUN chmod +x ~/.local/share/gh/extensions/*/gh-*
 
+# ---- Copy global Claude Code commands from host ----
+COPY --from=claude-global-commands --chown=dev:dev . /home/dev/.claude/commands/
+
 # Add custom scripts directory to PATH
 ENV PATH="/home/dev/custom-scripts:${PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,9 @@ COPY --from=gh-ext-pr-check --chown=dev:dev . /home/dev/.local/share/gh/extensio
 COPY --from=gh-ext-ai-review --chown=dev:dev . /home/dev/.local/share/gh/extensions/gh-ai-review
 RUN chmod +x ~/.local/share/gh/extensions/*/gh-*
 
-# ---- Copy global Claude Code commands from host ----
+# ---- Copy global Claude Code commands and agents from host ----
 COPY --from=claude-global-commands --chown=dev:dev . /home/dev/.claude/commands/
+COPY --from=claude-global-agents --chown=dev:dev . /home/dev/.claude/agents/
 
 # Add custom scripts directory to PATH
 ENV PATH="/home/dev/custom-scripts:${PATH}"

--- a/README.md
+++ b/README.md
@@ -223,6 +223,20 @@ docker compose run --rm -v /path/to/your/project:/workspace claude claude
 docker compose run --rm -v ./:/workspace claude claude
 ```
 
+### Claude Code Settings Sync
+
+ホストマシンの `~/.claude/` 配下の一部設定が Docker イメージに取り込まれます。
+
+**同期される設定:**
+- `~/.claude/commands/` - グローバルカスタムコマンド（Dockerfile の COPY でイメージに組み込み）
+
+**同期されない設定:**
+- `hooks` - サンドボックス専用の設定（gh コマンドリレー等）のため対象外
+- `settings.json` - ローカル環境固有の設定のため対象外
+- sandbox 設定 - Docker 環境では不要
+
+> **Note:** hooks の同期が必要になった場合は、別途 Issue を作成して対応します。
+
 ### Read-Only Mode
 
 To prevent accidental file modifications, you can mount your workspace as read-only:

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ docker compose run --rm -v ./:/workspace claude claude
 
 **同期される設定:**
 - `~/.claude/commands/` - グローバルカスタムコマンド（Dockerfile の COPY でイメージに組み込み）
+- `~/.claude/agents/` - グローバルカスタムエージェント（Dockerfile の COPY でイメージに組み込み）
 
 **同期されない設定:**
 - `hooks` - サンドボックス専用の設定（gh コマンドリレー等）のため対象外

--- a/custom-scripts/verify-docker-env.sh
+++ b/custom-scripts/verify-docker-env.sh
@@ -35,31 +35,46 @@ check "Claude Code CLI" "command -v claude"
 # 4. GitHub CLI
 check "gh CLI" "command -v gh"
 
-# 5. gh extensions
+# 5. gh auth
+check "gh auth" "gh auth status"
+
+# 6. gh extensions directory
 check "gh extensions directory" "[ -d ~/.local/share/gh/extensions ]"
 
-# 6. ripgrep
+# 7-10. Individual gh extensions
+check "gh-pr-unresolved" "gh pr-unresolved --help"
+check "gh-auto-review-fix" "gh auto-review-fix --help"
+check "gh-pr-check" "gh pr-check --help"
+check "gh-ai-review" "gh ai-review --help"
+
+# 11. ripgrep
 check "ripgrep" "command -v rg"
 
-# 7. Python3
+# 12. Python3
 check "Python3" "command -v python3"
 
-# 8. uv
+# 13. uv
 check "uv" "command -v uv"
 
-# 9. Workspace directory
+# 14. Workspace directory
 check "Workspace (/workspace)" "[ -d /workspace ]"
 
-# 10. Global commands
+# 15. Claude Code settings
+check "Claude Code settings" "[ -f /workspace/.claude/settings.local.json ] && jq empty /workspace/.claude/settings.local.json"
+
+# 16. Custom commands (project)
+check "Custom commands (project)" "[ -d /workspace/.claude/commands ] && [ -n \"\$(find /workspace/.claude/commands -maxdepth 1 -type f 2>/dev/null | head -1)\" ]"
+
+# 17. Global commands
 check "Global commands" "[ -d /home/dev/.claude/commands ] && [ -n \"\$(ls -A /home/dev/.claude/commands/ 2>/dev/null)\" ]"
 
-# 11. Global agents
+# 18. Global agents
 check "Global agents" "[ -d /home/dev/.claude/agents ] && [ -n \"\$(ls -A /home/dev/.claude/agents/ 2>/dev/null)\" ]"
 
-# 12. Custom scripts in PATH
+# 19. Custom scripts in PATH
 check "Custom scripts in PATH" "echo \"\$PATH\" | grep -q custom-scripts"
 
-# 13. Docker entrypoint
+# 20. Docker entrypoint
 check "Entrypoint script" "[ -x /home/dev/docker-entrypoint.sh ]"
 
 echo ""

--- a/custom-scripts/verify-docker-env.sh
+++ b/custom-scripts/verify-docker-env.sh
@@ -51,10 +51,13 @@ check "Workspace (/workspace)" "[ -d /workspace ]"
 # 9. Global commands
 check "Global commands" "[ -d /home/dev/.claude/commands ] && [ -n \"\$(ls -A /home/dev/.claude/commands/ 2>/dev/null)\" ]"
 
-# 10. Custom scripts in PATH
+# 10. Global agents
+check "Global agents" "[ -d /home/dev/.claude/agents ] && [ -n \"\$(ls -A /home/dev/.claude/agents/ 2>/dev/null)\" ]"
+
+# 11. Custom scripts in PATH
 check "Custom scripts in PATH" "echo \"\$PATH\" | grep -q custom-scripts"
 
-# 11. Docker entrypoint
+# 12. Docker entrypoint
 check "Entrypoint script" "[ -x /home/dev/docker-entrypoint.sh ]"
 
 echo ""

--- a/custom-scripts/verify-docker-env.sh
+++ b/custom-scripts/verify-docker-env.sh
@@ -41,23 +41,25 @@ check "gh extensions directory" "[ -d ~/.local/share/gh/extensions ]"
 # 6. ripgrep
 check "ripgrep" "command -v rg"
 
-# 7. Python / uv
+# 7. Python3
 check "Python3" "command -v python3"
+
+# 8. uv
 check "uv" "command -v uv"
 
-# 8. Workspace directory
+# 9. Workspace directory
 check "Workspace (/workspace)" "[ -d /workspace ]"
 
-# 9. Global commands
+# 10. Global commands
 check "Global commands" "[ -d /home/dev/.claude/commands ] && [ -n \"\$(ls -A /home/dev/.claude/commands/ 2>/dev/null)\" ]"
 
-# 10. Global agents
+# 11. Global agents
 check "Global agents" "[ -d /home/dev/.claude/agents ] && [ -n \"\$(ls -A /home/dev/.claude/agents/ 2>/dev/null)\" ]"
 
-# 11. Custom scripts in PATH
+# 12. Custom scripts in PATH
 check "Custom scripts in PATH" "echo \"\$PATH\" | grep -q custom-scripts"
 
-# 12. Docker entrypoint
+# 13. Docker entrypoint
 check "Entrypoint script" "[ -x /home/dev/docker-entrypoint.sh ]"
 
 echo ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
         gh-ext-pr-check: ~/Develop/mywork/claude-code/gh-pr-check
         gh-ext-ai-review: ~/Develop/mywork/claude-code/gh-ai-review
         claude-global-commands: ~/.claude/commands
+        claude-global-agents: ~/.claude/agents
     image: claude-code-cli:latest
     container_name: claude-code
     working_dir: /workspace

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
         gh-ext-auto-review-fix: ~/Develop/mywork/claude-code/gh-auto-review-fix
         gh-ext-pr-check: ~/Develop/mywork/claude-code/gh-pr-check
         gh-ext-ai-review: ~/Develop/mywork/claude-code/gh-ai-review
+        claude-global-commands: ~/.claude/commands
     image: claude-code-cli:latest
     container_name: claude-code
     working_dir: /workspace


### PR DESCRIPTION
## Summary

ホストマシンの `~/.claude/commands/` と `~/.claude/agents/` を Docker Compose の `additional_contexts` + Dockerfile `COPY --from=` パターンで Docker イメージに組み込む。これにより、グローバルカスタムコマンド・エージェントがコンテナ内でも利用可能になる。併せて、環境検証スクリプト `verify-docker-env.sh` を 20 項目チェック対応に拡張し、README に同期対象のドキュメントを追加。

Closes #1

## File Context (for reviewers)

### Files changed

**`Dockerfile`**
- Module-level context (already present, NOT in diff):
  - `FROM node:20-bullseye-slim` (L2)
  - `USER dev` (L51) — non-root user, COPY の `--chown=dev:dev` の対象
  - `WORKDIR /workspace` (L50)
  - `COPY --from=gh-ext-*` パターン (L56-59) — 今回追加する COPY と同じ `additional_contexts` パターン
  - `RUN chmod +x ~/.local/share/gh/extensions/*/gh-*` (L60)
- Helper patterns used in diff but defined elsewhere:
  - `additional_contexts` で定義されたビルドコンテキスト名 `claude-global-commands`, `claude-global-agents` は `docker-compose.yml` で定義

**`docker-compose.yml`**
- Module-level context (already present, NOT in diff):
  - `additional_contexts` ブロック (L8-12) — 既存の gh extension コンテキスト 4 つ
  - `volumes` マウント (L19-29) — `./custom-commands -> /workspace/.claude/commands` (プロジェクトレベル、今回追加のグローバルレベルとは別)

**`README.md`**
- Module-level context (already present, NOT in diff):
  - `## 🔧 Configuration` セクション (L191-) — 今回の追加はこのセクション内
  - `### Read-Only Mode` (L227-) — 追加セクションの直後に位置

**`custom-scripts/verify-docker-env.sh`** (大幅リライト)
- PR #9 で追加された 8 項目チェック版を 20 項目チェック版にリライト
- 構造変更: 個別の `check_command()`/`check_file()`/`check_json()` 関数 → 汎用 `check()` 関数 + `eval` パターン
- 旧スクリプトのチェック（gh auth, 個別 gh extension 検証, settings.json 検証, プロジェクトレベル commands）はすべて保持
- 依存: `set -euo pipefail` を維持、`eval` 内のコマンドは `if` ガード内で実行されるため `set -e` の影響を受けない

## Goal / Non-Goals

**Goal:**
- ホストの `~/.claude/commands/` をコンテナ内 `/home/dev/.claude/commands/` に組み込み、グローバルカスタムコマンドを利用可能にする
- ホストの `~/.claude/agents/` をコンテナ内 `/home/dev/.claude/agents/` に組み込み、グローバルカスタムエージェントを利用可能にする
- `verify-docker-env.sh` に Global commands / Global agents チェックを追加し、旧スクリプトのチェックも保持（20 項目）
- README に同期対象/非対象の設定をドキュメント化

**Non-Goals:**
- `hooks` の同期（サンドボックス専用の gh コマンドリレー等、ローカル環境固有）
- `settings.json` の同期（ローカル環境固有の設定）
- sandbox 設定の同期（Docker 環境では不要）
- `~/.claude/commands/` や `~/.claude/agents/` が存在しない場合のフォールバック機構

## Code Patterns

- `docker-compose.yml` の `additional_contexts` でホストディレクトリを Dockerfile ビルドコンテキストに渡す（既存の gh extension パターンと同一）
- `COPY --from=<context-name> --chown=dev:dev . <dest>` で non-root ユーザー所有権付きコピー
- `verify-docker-env.sh`: `set -euo pipefail` + `if eval ...` ガード、stderr リダイレクト付き

## Accepted Risks

- **`~/.claude/commands/` または `~/.claude/agents/` が存在しない場合、`docker compose build` が失敗する**
  - Reason: `additional_contexts` で参照するディレクトリが存在しない場合は Docker Compose が事前にエラーを出す。ホストに Claude Code がインストールされている前提のため、通常は存在する
  - Fallback: エラーメッセージが明確なため、`mkdir -p ~/.claude/commands ~/.claude/agents` で即解決可能

- **`verify-docker-env.sh` 内の `eval` 使用**
  - Reason: チェック条件はスクリプト内にハードコードされた文字列のみ（ユーザー入力は受け付けない）
  - Fallback: インジェクションリスクなし。コード所有者のみが条件文字列を定義

## Test Plan

- [x] `shellcheck custom-scripts/verify-docker-env.sh` パス
- [x] `docker compose config` で YAML 構文検証
- [x] `docker compose build` 成功
- [x] コンテナ内で `verify-docker-env.sh` 実行、20/20 チェック通過
- [x] コンテナ内で `ls /home/dev/.claude/commands/` にグローバルコマンドが存在
- [x] コンテナ内で `ls /home/dev/.claude/agents/` にグローバルエージェントが存在

🤖 Generated with [Claude Code](https://claude.com/claude-code)